### PR TITLE
Make options object arg optional

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -12,6 +12,7 @@ var Transmission = module.exports = function(options) {
 
 	events.EventEmitter.call(this);
 
+	options = options || {};
 	this.url = options.url || '/transmission/rpc';
 	this.host = options.host || 'localhost';
 	this.port = options.port || 9091;


### PR DESCRIPTION
First using this library, like most of the libraries, I thought the constructor options argument was optional, and wrote code like this:

```
transmission = new Transmission
```

Which was supposed to be:

```
transmission = new Transmission({})
```

So this will fix the trap for the next developer getting started with this library.
