### PR TITLE
Add support for duplicate torrents

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -54,7 +54,7 @@ Transmission.prototype.add = function(path, options, callback) {
 		if (err) {
 			return callback(err)
 		}
-		var torrent = result['torrent-added']
+		var torrent = result['torrent-duplicate'] ? result['torrent-duplicate'] : result['torrent-added']
 		callback(err, torrent)
 	})
 }


### PR DESCRIPTION
If the torrent already exists then the result is returned in 'torrent-duplicate' not 'torrent-added'
