### PR TITLE
Can't set session params

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -345,7 +345,7 @@ Transmission.prototype.session = function(data, callback) {
 			tag : uuid()
 		};
 	}
-	this.callServer(options, data);
+	this.callServer(options, callback);
 	return this;
 };
 


### PR DESCRIPTION
Hi,

You need a callback to call the server. Else you will have the error

events.js:142
    throw TypeError('listener must be a function');

Regards,