### PR TITLE
Fixed server calls on set/read session

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -339,13 +339,14 @@ Transmission.prototype.session = function(data, callback) {
 			method : this.methods.session.set,
 			tag : uuid()
 		};
+		this.callServer(options, callback);
 	} else {
 		options = {
 			method : this.methods.session.get,
 			tag : uuid()
 		};
+		this.callServer(options, data);
 	}
-	this.callServer(options, data);
 	return this;
 };
 


### PR DESCRIPTION
A program like this should work correctly now

```coffee
Transmission = require  'transmission'

transmission = new Transmission
    port : 9091,
    host : '127.0.0.1'

transmission.session
  'peer-limit-global': 400
  'speed-limit-down-enabled': true
  'speed-limit-up-enabled' : true
,(err, arg) ->
  console.log err, arg

transmission.session (err, results)->
  console.log results
```