### PR TITLE
callback the readFile error

### DIFF
--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -60,7 +60,7 @@ Transmission.prototype.addFile = function(filePath, options, callback) {
 	var self = this;
 	fs.readFile(filePath, function(err, data){
 		if (err) {
-			throw err;
+			callback(err);
 		}
 		var fileContentBase64 = new Buffer(data).toString('base64');
 	    var args = {};


### PR DESCRIPTION
You can't catch an asynchronous error.
Please, take a look to the node.js Error API (with exactly the same situation):
https://nodejs.org/api/errors.html#errors_node_js_style_callbacks