### PR TITLE
Add free-space RPC call

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ Get client session stats.
 transmission.sessionStats(function(err, arg){});
 ```
 
+### transmission.freeSpace(path, callback)
+
+Get free space available on the server for the specified directory.
+
+```js
+transmission.freeSpace(path, function(err, arg){});
+```
+
 ### All together.
 
 ```js

--- a/lib/transmission.js
+++ b/lib/transmission.js
@@ -413,6 +413,16 @@ Transmission.prototype.sessionStats = function (callback) {
     this.callServer(options, callback);
 };
 
+Transmission.prototype.freeSpace = function (path, callback) {
+    this.callServer({
+        arguments: {
+            path: path
+        },
+        method: this.methods.other.freeSpace
+    }, callback);
+    return this;
+};
+
 Transmission.prototype.callServer = function (query, callBack) {
     var self = this;
     var queryJsonify = JSON.stringify(query);
@@ -574,6 +584,7 @@ Transmission.prototype.methods = {
     },
     other: {
         blockList: 'blocklist-update',
-        port: 'port-test'
+        port: 'port-test',
+        freeSpace: 'free-space'
     }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "transmission",
   "description": "API client for transmissionbt",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "scripts": {
     "test": "mocha --ui bdd --reporter spec --colors --slow 10000"
   },


### PR DESCRIPTION
Adds the `free-space` method from the [Transmission RPC Spec](https://github.com/transmission/transmission/blob/master/extras/rpc-spec.txt).

Tested by locally linking the module and including in a separate project.  Let me know if I should go about it another way.